### PR TITLE
Simplify the API by just accepting single callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,44 +54,31 @@ func Sum(a int, b int) int {
     return a + b
 }
 
-// TestSum is a agenda.Test-compatible type
-// that holds input and output data for the test,
-// and does the computation and serialization
-type TestSum struct {
-    input struct {
-        A int `json:"a"`
-        B int `json:"b"`
-    }
-    output struct {
-        Result int `json:"result"`
-    }
-}
+// TestSum is the test for Sum()
+func TestSum(t *testing.T) {
+    agenda.Run(t, "testdata/sum", func(path string, data []byte) ([]byte, error) {
+        // input data structure
+        in := struct {
+            A int `json:"a"`
+            B int `json:"b"`
+        }{}
 
-// UnmarshalInput is called to unmarshal raw bytes
-// from the external test file into test input structure.
-func (t *TestSum) UnmarshalInput(data []byte) error {
-    return json.Unmarshal(data, &t.input)
-}
+        // output data structure
+        out := struct {
+            Result int `json:"result"`
+        }{}
 
-// Run executes the actual test. Note there's no assertion here;
-// one just need to run the business logic
-// and store the output internally.
-func (t *TestSum) Run() error {
-    t.output.Result = Sum(t.input.A, t.input.B)
-    return nil
-}
+        // deserialize provided input data
+        if err := json.Unmarshal(data, &in); err != nil {
+            return nil, err
+        }
 
-// MarshalOutput serializes output to raw bytes
-// suitable for saving into file and for comparison.
-func (t *TestSum) MarshalOutput() ([]byte, error) {
-    return json.Marshal(t.output)
-}
+        // run the test and populate output data structure
+        out.Result = Sum(in.A, in.B)
 
-// The actual test executed by `go test`;
-// agenda.Run() will scan `testdata/sum` directory
-// for .json files, and run test for each of them.
-func TestSumWithAgenda(t *testing.T) {
-    agenda.Run(t, "testdata/sum", &TestSum{})
+        // return serialized output data
+        return json.Marshal(out)
+    })
 }
 ```
 

--- a/agenda_test.go
+++ b/agenda_test.go
@@ -9,63 +9,53 @@ import (
 	"testing"
 )
 
-// Test01 represents a simple test with JSON serialization
-type Test01 struct {
-	input struct {
+// test01 is a sample test calback function
+// that uses JSON to store both input and output data
+func test01(path string, data []byte) ([]byte, error) {
+	in := struct {
 		A float64 `json:"a"`
 		B float64 `json:"b"`
 		C float64 `json:"c"`
-	}
-	output struct {
+	}{}
+
+	out := struct {
 		Sum         float64     `json:"sum"`
 		Mul         float64     `json:"mul"`
 		Div         float64     `json:"div"`
 		Error       interface{} `json:"error"`
 		Explanation string      `json:"explanation"`
+	}{}
+
+	if err := json.Unmarshal(data, &in); err != nil {
+		return nil, err
 	}
-}
 
-func (t *Test01) UnmarshalInput(data []byte) error {
-	return json.Unmarshal(data, &t.input)
-}
-
-func (t *Test01) Run() error {
-	// reset the output struct between the runs
-	t.output.Div = 0
-	t.output.Error = nil
-
-	// fill the output struct with values
-	t.output.Sum = t.input.A + t.input.B + t.input.C
-	t.output.Mul = t.input.A * t.input.B * t.input.C
-	if t.input.B == 0 {
-		t.output.Error = SerializableError(errors.New("Can't divide: B is zero"))
-	} else if t.input.C == 0 {
-		t.output.Error = SerializableError(errors.New("Can't divide: C is zero"))
+	out.Sum = in.A + in.B + in.C
+	out.Mul = in.A * in.B * in.C
+	if in.B == 0 {
+		out.Error = SerializableError(errors.New("Can't divide: B is zero"))
+	} else if in.C == 0 {
+		out.Error = SerializableError(errors.New("Can't divide: C is zero"))
 	} else {
-		t.output.Div = float64(t.input.A) / float64(t.input.B) / float64(t.input.C)
+		out.Div = float64(in.A) / float64(in.B) / float64(in.C)
 	}
-	t.output.Explanation = fmt.Sprintf(
-		"Input parameters were: [%v, %v, %v]", t.input.A, t.input.B, t.input.C,
+	out.Explanation = fmt.Sprintf(
+		"Input parameters were: [%v, %v, %v]", in.A, in.B, in.C,
 	)
-	// no supporting code in the test itself produces errors,
-	// so we always return nil
-	return nil
-}
 
-func (t *Test01) MarshalOutput() ([]byte, error) {
-	return json.Marshal(t.output)
+	return json.Marshal(out)
 }
 
 // Test01RunDefault runs agenda tests with the default parameters
 // (it will look for files ending with .json)
 func Test01RunDefault(t *testing.T) {
-	Run(t, "testdata/01/default", &Test01{})
+	Run(t, "testdata/01/default", test01)
 }
 
 // Test01RunWithCustomFileSuffix runs tests with custom file suffix option:
 // only files ending with '.custom' will be considered as tests
 func Test01RunWithCustomFileSuffix(t *testing.T) {
-	Run(t, "testdata/01/custom-file-suffix", &Test01{},
+	Run(t, "testdata/01/custom-file-suffix", test01,
 		FileSuffix(".custom"))
 }
 
@@ -74,56 +64,50 @@ func Test01RunWithCustomFileSuffix(t *testing.T) {
 // for each file ending with '.in' there will be a '.in.out' file
 // with serialized results
 func Test01RunWithCustomFileAndResultSuffix(t *testing.T) {
-	Run(t, "testdata/01/custom-file-result-suffix", &Test01{},
+	Run(t, "testdata/01/custom-file-result-suffix", test01,
 		FileSuffix(".in"), ResultSuffix(".out"))
-}
-
-type FileRec struct {
-	Path string `json:"path"`
-	Size int64  `json:"size"`
-}
-
-// TestDirectorySnapshot represents a test that compares directories
-type TestDirectorySnapshot struct {
-	input struct {
-		Path string `json:"path"`
-	}
-	output []*FileRec
-}
-
-func (t *TestDirectorySnapshot) UnmarshalInput(data []byte) error {
-	return json.Unmarshal(data, &t.input)
-}
-
-func (t *TestDirectorySnapshot) Run() error {
-	t.output = make([]*FileRec, 0)
-	err := filepath.Walk(
-		t.input.Path,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return err
-			}
-			if info.IsDir() {
-				return nil
-			}
-			t.output = append(
-				t.output,
-				&FileRec{path, info.Size()},
-			)
-			return nil
-		},
-	)
-	return err
-}
-
-func (t *TestDirectorySnapshot) MarshalOutput() ([]byte, error) {
-	// Pretty-print the JSON for easier diff-ing
-	return json.MarshalIndent(t.output, "", "\t")
 }
 
 // TestDirectorySnapshotRun01Default runs agenda tests
 // to verify that the contents of the test folders generated
 // by previous tests matches the expectations
 func TestDirectorySnapshotRun01Default(t *testing.T) {
-	Run(t, "testdata/dir-snapshots", &TestDirectorySnapshot{})
+	Run(t, "testdata/dir-snapshots", func(path string, data []byte) ([]byte, error) {
+		type FileRec struct {
+			Path string `json:"path"`
+			Size int64  `json:"size"`
+		}
+
+		in := struct {
+			Path string `json:"path"`
+		}{}
+
+		out := make([]*FileRec, 0)
+
+		if err := json.Unmarshal(data, &in); err != nil {
+			return nil, err
+		}
+
+		if err := filepath.Walk(
+			in.Path,
+			func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.IsDir() {
+					return nil
+				}
+				out = append(
+					out,
+					&FileRec{path, info.Size()},
+				)
+				return nil
+			},
+		); err != nil {
+			return nil, err
+		}
+
+		// Pretty-print the JSON for easier diff-ing
+		return json.MarshalIndent(out, "", "\t")
+	})
 }

--- a/example/example_agenda_test.go
+++ b/example/example_agenda_test.go
@@ -1,6 +1,6 @@
 /*
 
-These are data-snapshot-driven tests
+These are agenda-driven tests
 
 */
 package example
@@ -12,93 +12,68 @@ import (
 	"github.com/iafan/agenda"
 )
 
-// Sum
+func TestSum(t *testing.T) {
+	agenda.Run(t, "testdata/sum", func(path string, data []byte) ([]byte, error) {
+		in := struct {
+			A int `json:"a"`
+			B int `json:"b"`
+		}{}
 
-type TestSum struct {
-	input struct {
-		A int `json:"a"`
-		B int `json:"b"`
-	}
-	output struct {
-		Result int `json:"result"`
-	}
+		out := struct {
+			Result int `json:"result"`
+		}{}
+
+		if err := json.Unmarshal(data, &in); err != nil {
+			return nil, err
+		}
+
+		out.Result = Sum(in.A, in.B)
+
+		return json.Marshal(out)
+	})
 }
 
-func (t *TestSum) UnmarshalInput(data []byte) error {
-	return json.Unmarshal(data, &t.input)
+func TestMul(t *testing.T) {
+	agenda.Run(t, "testdata/mul", func(path string, data []byte) ([]byte, error) {
+		in := struct {
+			A int `json:"a"`
+			B int `json:"b"`
+		}{}
+
+		out := struct {
+			Result int `json:"result"`
+		}{}
+
+		if err := json.Unmarshal(data, &in); err != nil {
+			return nil, err
+		}
+
+		out.Result = Mul(in.A, in.B)
+
+		return json.Marshal(out)
+	})
 }
 
-func (t *TestSum) Run() error {
-	t.output.Result = Sum(t.input.A, t.input.B)
-	return nil
-}
+func TestDiv(t *testing.T) {
+	agenda.Run(t, "testdata/div", func(path string, data []byte) ([]byte, error) {
+		in := struct {
+			A int `json:"a"`
+			B int `json:"b"`
+		}{}
 
-func (t *TestSum) MarshalOutput() ([]byte, error) {
-	return json.Marshal(t.output)
-}
+		out := struct {
+			Result int         `json:"result"`
+			Error  interface{} `json:"error"`
+		}{}
 
-func TestSumWithAgenda(t *testing.T) {
-	agenda.Run(t, "testdata/sum", &TestSum{})
-}
+		if err := json.Unmarshal(data, &in); err != nil {
+			return nil, err
+		}
 
-// Mul
+		var err error
+		out.Result, err = Div(in.A, in.B)
+		out.Error = agenda.SerializableError(err)
 
-type TestMul struct {
-	input struct {
-		A int `json:"a"`
-		B int `json:"b"`
-	}
-	output struct {
-		Result int `json:"result"`
-	}
-}
-
-func (t *TestMul) UnmarshalInput(data []byte) error {
-	return json.Unmarshal(data, &t.input)
-}
-
-func (t *TestMul) Run() error {
-	t.output.Result = Mul(t.input.A, t.input.B)
-	return nil
-}
-
-func (t *TestMul) MarshalOutput() ([]byte, error) {
-	return json.Marshal(t.output)
-}
-
-func TestMulWithAgenda(t *testing.T) {
-	agenda.Run(t, "testdata/mul", &TestMul{})
-}
-
-// Div
-
-type TestDiv struct {
-	input struct {
-		A int `json:"a"`
-		B int `json:"b"`
-	}
-	output struct {
-		Result int         `json:"result"`
-		Error  interface{} `json:"error"`
-	}
-}
-
-func (t *TestDiv) UnmarshalInput(data []byte) error {
-	return json.Unmarshal(data, &t.input)
-}
-
-func (t *TestDiv) Run() error {
-	var err error
-	t.output.Result, err = Div(t.input.A, t.input.B)
-	t.output.Error = agenda.SerializableError(err)
-
-	return nil
-}
-
-func (t *TestDiv) MarshalOutput() ([]byte, error) {
-	return json.Marshal(t.output)
-}
-
-func TestDivWithAgenda(t *testing.T) {
-	agenda.Run(t, "testdata/div", &TestDiv{})
+		return json.Marshal(out)
+	})
 }


### PR DESCRIPTION
It looks like having a single callback function instead of an interface with unmarhsal/run/marshal steps is enough. The code becomes cleaner.